### PR TITLE
Add async/await when fetching from channel api

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ client.once('ready', () => {
   client.user.setActivity(`${prefix}help`, { type: Discord.ActivityType.Listening });
 });
 
-const bind = (messageObj, callback, errorCb) => {
+const bind = async (messageObj, callback, errorCb) => {
   const tokens = utils.tokenize(messageObj.content);
   if (messageObj.member.permissions.has('MANAGE_GUILD') && tokens.length > 1) {
     const channelId = tokens[1].trim().replace(/\D/g, '');
-    client.channels
+    await client.channels
       .fetch(channelId)
       .catch((e) => {
         if (errorCb) {
@@ -51,7 +51,7 @@ const bind = (messageObj, callback, errorCb) => {
   } else if (errorCb) errorCb();
 };
 
-client.on('messageCreate', (message) => {
+client.on('messageCreate', async (message) => {
   try {
     const { author } = message;
     if (author.bot) return; // message from bot
@@ -69,7 +69,7 @@ client.on('messageCreate', (message) => {
     if (message.content.startsWith(prefix)) {
       const command = tokens[0].substr(prefix.length);
       if (command === 'bind') {
-        bind(message);
+        await bind(message);
       }
       if (!data.getChannelId()) {
         // unbound


### PR DESCRIPTION
According to issue #27, there is an issue when binding to a channel.

Steps to reproduce
 - Log the bot into a server
 - Ensure the file `data.json` does not exist so a new one will be created 
 - Start the application
 - Bind the bot to a channel
 - The message `Bot must be bound to a channel with t?bind #<channel-name>.` is sent right below the bind command

this happens when `index.js:72` calls the `bind` method without waiting for the request to be fulfilled so that `data.setChannelId()` in `index.js:48` may not be reached in a timely manner and the binding error message will be sent to channel.

This pull request adds `await` before the call to bind in order to check `channelId` content only after the call to channel's api has been fulfilled